### PR TITLE
feat: add callout support

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,5 +1,6 @@
 import syntaxHighlight from "@11ty/eleventy-plugin-syntaxhighlight";
 import footnote_plugin from "markdown-it-footnote";
+import MarkdownItGitHubAlerts from "markdown-it-github-alerts";
 import { IdAttributePlugin } from "@11ty/eleventy";
 import { execSync } from "child_process";
 
@@ -10,7 +11,10 @@ export default function(eleventyConfig) {
   eleventyConfig.setInputDirectory("content");
   eleventyConfig.addPassthroughCopy("assets");
 
-  eleventyConfig.amendLibrary("md", (mdLib) => mdLib.use(footnote_plugin));
+  eleventyConfig.amendLibrary("md", (mdLib) => {
+    mdLib.use(footnote_plugin)
+    mdLib.use(MarkdownItGitHubAlerts)
+  });
   eleventyConfig.addShortcode("lastEdited", findLastEdited);
 }
 

--- a/content/eduroam.md
+++ b/content/eduroam.md
@@ -10,37 +10,38 @@ layout: base.njk
 
 *(Want to connect to UNSW-IoT instead? See [/iot](/iot))*
 
-**⚠️ disclaimer: ⚠️ this is (predominately) a guide for a tool not written/managed by the linux society. please use your own best judgement when using third party tools which handle your unsw credentials. you use third party tools at your own risk and we are not responsible for any damage arising from your use of them.**
+> [!WARNING]
+> This is (predominately) a guide for a tool not written/managed by the Linux Society. Please use your own best judgement when using third party tools which handle your UNSW credentials. You use third party tools at your own risk and we are not responsible for any damage arising from your use of them.
 
-**tldr: try [arubaquickconnect4all](https://github.com/alzer89/ArubaQuickConnect4All)**
+**TLDR: try [arubaquickconnect4all](https://github.com/alzer89/ArubaQuickConnect4All)**
 
-eduroam at unsw is an aruba-managed wireless network, meaning that it only officially supports ubuntu. if you are looking to connect on a distro other than ubuntu, an option is [arubaquickconnect4all](https://github.com/alzer89/ArubaQuickConnect4All).
-by doing so, you will get higher speeds compared to using unsw-iot :)
+Eduroam at UNSW is an Aruba-managed wireless network, meaning that it only officially supports Ubuntu. If you are looking to connect on a distro other than Ubuntu, an option is [arubaquickconnect4all](https://github.com/alzer89/ArubaQuickConnect4All).
+By doing so, you (may) get higher speeds compared to using UNSW-IoT :)
 
-all the following steps assume you have cloned the repo already (see steps on github).
+All the following steps assume you have cloned the repo already (see steps on Github).
 
-## running with geckodriver (firefox):
+## Running with Geckodriver (Firefox):
 
-geckodriver seems to work better than chromedriver. install it via your distro's package manager.
+Geckodriver seems to work better than Chromedriver. Install it via your distro's package manager, or find it [here](https://github.com/mozilla/geckodriver/releases).
 
 ```sh
 pip install .
 aqc4all --browser firefox
 ```
 
-## what is the 'onboarding portal url'
+## What is the 'onboarding portal URL'?
 
-1. go here: [unsw get online](https://www.unsw.edu.au/myit/services/wifi-network/connecting-to-the-unsw-network/get-online/standard-unsw-linux-device)
-2. click get online
-3. accept the terms and conditions
-4. select 'personal device'
-5. the onboarding portal link is the page's domain
+1. Go here: [UNSW Get Online](https://www.unsw.edu.au/myit/services/wifi-network/connecting-to-the-unsw-network/get-online/standard-unsw-linux-device)
+2. Click 'Get Online'
+3. Accept the terms and conditions
+4. Select 'personal device'
+5. The onboarding portal link is the page's domain
 
-an example is if we have a site such as https://linsoc.cc/join, the domain part you would provide would be https://linsoc.cc.
+An example is if we have a site such as https://linsoc.cc/join, the domain part you would provide would be https://linsoc.cc.
 
-## 'this environment is externally managed' when i run `pip install`
+## 'This environment is externally managed' when I run `pip install`
 
-create a virtual environment first/use uv.
+Create a virtual environment first/use `uv`.
 
 ```sh
 python -m venv venv
@@ -48,15 +49,16 @@ source venv/bin/activate
 pip install .
 ```
 
-if you have uv, just run `uv run aqc4all`
+if you have `uv`, just run `uv run aqc4all`
 
-## 'none not found' when i run the program
+## ‘None not found’ when I run the `acq4all`
 
-you are missing either chromedriver or geckodriver. install this via your distro's package manager. if you choose geckodriver, make sure you use the `--browser firefox` flag.
+You are missing either Chromedriver or Geckodriver. Install this via your distro's package manager. If you choose Geckodriver, make sure you use the `--browser firefox` flag.
 
-## i don't want to use aqc4all!
+## I don't want to use `aqc4all`!
 
-please note that the below is a temporary solution which may stop working at any time.
+>[!WARNING]
+> Please note that the below is a temporary solution which may stop working at any time. The following also **stores your UNSW password in plaintext.**
 
 ```sh
  nmcli connection edit
@@ -82,10 +84,8 @@ please note that the below is a temporary solution which may stop working at any
 
     quit # if you want to leave
 
-# (note: password is like written in plaintext so dont show anyone :3)
-
 ```
 
-## have an issue not found here?
+## Have an issue not found here?
 
-find us in the [linux society discord](https://linsoc.cc/discord) and we can help with troubleshooting :) this guide is also a work in progress! please give us feedback <3
+Find us in the [Linux Society Discord](https://linsoc.cc/discord) and we can help with troubleshooting :) This guide is also a work in progress! Please give us feedback <3

--- a/content/wifi.md
+++ b/content/wifi.md
@@ -61,7 +61,8 @@ an IoT device.
 
 ### Legacy Eduroam
 
-**⚠️ warning: ⚠️ this connection method has known security issues**
+>[!WARNING]
+> This connection method has known security issues.
 
 _Read the [full section](/eduroam#i-dont-want-to-use-aqc4all)_
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",
-        "markdown-it-footnote": "^4.0.0"
+        "markdown-it-footnote": "^4.0.0",
+        "markdown-it-github-alerts": "^1.0.1"
       },
       "devDependencies": {
         "@11ty/eleventy": "^3.1.2"
@@ -311,7 +312,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-differ": {
@@ -1102,7 +1102,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
@@ -1150,7 +1149,6 @@
       "version": "14.1.1",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
       "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
@@ -1170,11 +1168,22 @@
       "integrity": "sha512-WYJ7urf+khJYl3DqofQpYfEYkZKbmXmwxQV8c8mO/hGIhgZ1wOe7R4HLFNwqx7TjILbnC98fuyeSsin19JdFcQ==",
       "license": "MIT"
     },
+    "node_modules/markdown-it-github-alerts": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-github-alerts/-/markdown-it-github-alerts-1.0.1.tgz",
+      "integrity": "sha512-NNATF4QdoGI07hyCitoB2YqJ1YcNVCKT89ut2VtfFY9rkeFCXe/V2lOonKQLpJiq5DjiZZepf97BJx5xOjFIAw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "markdown-it": ">= 13.0.0"
+      }
+    },
     "node_modules/markdown-it/node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -1203,7 +1212,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mime": {
@@ -1484,7 +1492,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
       "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -1698,7 +1705,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",
-    "markdown-it-footnote": "^4.0.0"
+    "markdown-it-footnote": "^4.0.0",
+    "markdown-it-github-alerts": "^1.0.1"
   }
 }

--- a/style/style.css
+++ b/style/style.css
@@ -177,3 +177,59 @@ img {
     height: auto;
     display: block;
 }
+
+/* github callout */
+.markdown-alert {
+  padding: 0.8rem 1rem;
+  margin: 1rem 0;
+  border-left: 4px solid;
+  background-color: #1f1f1f;
+}
+
+.markdown-alert-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.markdown-alert > :first-child {
+  margin-top: 0;
+}
+
+.markdown-alert > :last-child {
+  margin-bottom: 0.5rem;
+}
+
+.markdown-alert-title svg {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  fill: #ffffff;
+}
+
+.markdown-alert-title {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.markdown-alert-warning {
+  border-left: 4px solid;
+    border-color: #fbc630;
+    background-color: #fbc63016
+}
+
+.markdown-alert-warning .markdown-alert-title svg {
+    fill: #fbc630;
+}
+
+/* these variants can be added as needed */
+/*
+.markdown-alert-tip {
+}
+
+.markdown-alert-important {
+}
+
+.markdown-alert-caution {
+}
+*/


### PR DESCRIPTION
adds support for github-style callouts

- only the warning is styled properly, i haven't thought about colours for other types at the moment - if someone chooses to use them, they can implement the styling if needed before i get to it
- also converts the current warning-emoji style disclaimers to use the new callouts

an example:

<img width="733" height="217" alt="image" src="https://github.com/user-attachments/assets/b124609b-5e24-4559-9eb3-f6b90d4fd49a" />
